### PR TITLE
Ignore gs warnings to get a clean output.

### DIFF
--- a/src/Ghostscript.php
+++ b/src/Ghostscript.php
@@ -206,6 +206,7 @@ class Ghostscript
         $command[] = '-dNOPAUSE';
         $command[] = '-dSAFER';
         $command[] = '-sOutputFile=%stdout';
+        $command[] = '-sstdout=%stderr';
         $command[] = '-q';
         $command[] = $file->getLocalPath();
 


### PR DESCRIPTION
I am using this library to get an image for the first page of PDF file.

For some PDF files i was getting some warnings about PDF errors before the image, so it was not valid.

Using the parameter -sstdout=%stderr will fix it.

